### PR TITLE
31 feat: Terraform plan/apply Discord Webhook 작업 

### DIFF
--- a/.github/workflows/terraform-apply-sandbox.yml
+++ b/.github/workflows/terraform-apply-sandbox.yml
@@ -6,6 +6,9 @@ on:
       reason:
         description: "왜 apply를 실행하나요?"
         required: true
+      plan_commit:
+        description: "적용할 plan 기준 commit SHA"
+        required: true
 
 jobs:
   terraform-apply:
@@ -20,6 +23,7 @@ jobs:
         run: |
           echo "## 🚀 Terraform Apply (sandbox)" >> $GITHUB_STEP_SUMMARY
           echo "- Actor: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Plan Commit: ${{ github.event.inputs.plan_commit }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Reason:** ${{ github.event.inputs.reason }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -63,27 +67,29 @@ jobs:
             -auto-approve \
             -var-file="sandbox.tfvars"
 
+      # ✅ Apply 성공 → plan 스레드에 이어서 메시지 전송
       - name: Send Discord Notification (Apply Success)
         if: success()
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
           if [ -n "$DISCORD_WEBHOOK_URL" ]; then
-            THREAD_NAME="[Success] Terraform Apply (sandbox) @${{ github.sha }}"
-            MESSAGE="⭕ **Terraform Apply (sandbox) 성공**\n\n- Branch: sandbox\n- Commit: ${{ github.sha }}\n- Reason: ${{ github.event.inputs.reason }}\n- Workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            THREAD_NAME="plan:sandbox:${{ github.event.inputs.plan_commit }}"
+            MESSAGE="🚀 **Terraform Apply (sandbox) 성공**\n\n- Plan Commit: ${{ github.event.inputs.plan_commit }}\n- Apply Commit: ${{ github.sha }}\n- Actor: ${{ github.actor }}\n- Reason: ${{ github.event.inputs.reason }}\n- Workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             curl -X POST "$DISCORD_WEBHOOK_URL" \
               -H "Content-Type: application/json" \
               -d "{\"content\": \"$MESSAGE\", \"thread_name\": \"$THREAD_NAME\"}"
           fi
 
+      # ❌ Apply 실패 → 동일한 plan 스레드에 실패 메시지
       - name: Send Discord Notification (Apply Failure)
         if: failure()
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
           if [ -n "$DISCORD_WEBHOOK_URL" ]; then
-            THREAD_NAME="[Failure] Terraform Apply (sandbox) @${{ github.sha }}"
-            MESSAGE="❌ **Terraform Apply (sandbox) 실패**\n\n- Branch: sandbox\n- Commit: ${{ github.sha }}\n- Reason: ${{ github.event.inputs.reason }}\n- Workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            THREAD_NAME="plan:sandbox:${{ github.event.inputs.plan_commit }}"
+            MESSAGE="❌ **Terraform Apply (sandbox) 실패**\n\n- Plan Commit: ${{ github.event.inputs.plan_commit }}\n- Apply Commit: ${{ github.sha }}\n- Actor: ${{ github.actor }}\n- Reason: ${{ github.event.inputs.reason }}\n- Workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             curl -X POST "$DISCORD_WEBHOOK_URL" \
               -H "Content-Type: application/json" \
               -d "{\"content\": \"$MESSAGE\", \"thread_name\": \"$THREAD_NAME\"}"
@@ -94,4 +100,5 @@ jobs:
         run: |
           echo "### Result" >> $GITHUB_STEP_SUMMARY
           echo "- Status: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Commit: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Plan Commit: ${{ github.event.inputs.plan_commit }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Apply Commit: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/terraform-plan-sandbox.yml
+++ b/.github/workflows/terraform-plan-sandbox.yml
@@ -53,36 +53,38 @@ jobs:
             -var-file="sandbox.tfvars" \
             -no-color | tee plan.txt
 
+      # 항상 Summary 기록
       - name: Plan Summary
-        if: always() # 성공/실패 무관하게 항상 Summary 기록
+        if: always()
         run: |
           echo "## Terraform Plan (sandbox)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- Branch: sandbox" >> $GITHUB_STEP_SUMMARY
           echo "- Commit: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Result: 완료" >> $GITHUB_STEP_SUMMARY
+          echo "- Status: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
 
-      # Discord 알림은 success / failure 분리
+      # ✅ Plan 성공 → 동일한 스레드 이름 사용
       - name: Send Discord Notification (Plan Success)
         if: success()
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
           if [ -n "$DISCORD_WEBHOOK_URL" ]; then
-            THREAD_NAME="[Success] Terraform Plan (sandbox) @${{ github.sha }}"
+            THREAD_NAME="plan:sandbox:${{ github.sha }}"
             MESSAGE="⭕ **Terraform Plan (sandbox) 완료**\n\n- Branch: sandbox\n- Commit: ${{ github.sha }}\n- Workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             curl -X POST "$DISCORD_WEBHOOK_URL" \
               -H "Content-Type: application/json" \
               -d "{\"content\": \"$MESSAGE\", \"thread_name\": \"$THREAD_NAME\"}"
           fi
 
+      # ❌ Plan 실패 → 스레드 이름은 동일, 메시지만 실패 표시
       - name: Send Discord Notification (Plan Failure)
         if: failure()
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
           if [ -n "$DISCORD_WEBHOOK_URL" ]; then
-            THREAD_NAME="[FAILED] Terraform Plan (sandbox) @${{ github.sha }}"
+            THREAD_NAME="plan:sandbox:${{ github.sha }}"
             MESSAGE="❌ **Terraform Plan (sandbox) 실패**\n\n- Branch: sandbox\n- Commit: ${{ github.sha }}\n- Workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             curl -X POST "$DISCORD_WEBHOOK_URL" \
               -H "Content-Type: application/json" \


### PR DESCRIPTION
- Terraform plan 결과를 Discord 채널에 스레드 메시지로 기록하도록 구성했습니다.
- Terraform apply는 workflow_dispatch를 통해 수동으로 실행하며,
apply 실행 시 기준이 되는 plan 커밋 번호를 입력하면 해당 plan 스레드에 apply 결과가 자동으로 이어서 기록되도록 했습니다.

초기에는 sandbox 인프라의 실행/종료(start/stop) 작업까지 함께 처리할지 고민했으나,
ECS(EC2), RDS, ALB 등 기본 인프라 구성이 선행되지 않은 상태에서 start/stop 기능을 구현하는 것은 테스트 및 작업 순서 측면에서 적절하지 않다고 판단했습니다.

따라서 이번 작업에서는
인프라 변경 관리(plan/apply 흐름) 정립에만 집중하고,
sandbox 인프라 실행/종료 자동화는 인프라 구성이 안정화된 이후 단계에서 진행하기로 결정했습니다.

### 🔗 Related Issue

Closes #31

