### PR TITLE
feat: moit.kr apex를 Vercel로 라우팅

### DIFF
--- a/component/prod/main.tf
+++ b/component/prod/main.tf
@@ -80,3 +80,16 @@ resource "aws_route53_record" "alb_alias" {
     evaluate_target_health = true
   }
 }
+
+# moit.kr apex를 Vercel(프론트엔드)로 보낸다.
+# Route53 alias는 AWS 리소스만 대상으로 할 수 있어 A 레코드로 IP를 직접 지정한다.
+# sandbox는 zone apex(dev.moit.kr)가 곧 ALB 도메인이라 레코드가 충돌하므로 prod만 생성한다.
+resource "aws_route53_record" "vercel_apex" {
+  count = var.environment == "prod" ? 1 : 0
+
+  zone_id = aws_route53_zone.primary[0].zone_id
+  name    = local.route53_zone_name
+  type    = "A"
+  ttl     = 300
+  records = ["216.198.79.1"]
+}


### PR DESCRIPTION
## 배경

프론트엔드가 Vercel에 배포되어 `moit.kr` apex를 Vercel로 보내야 합니다.
현재 `moit.kr` zone에는 `api.moit.kr`(ALB) 레코드만 있고 apex 레코드가 없습니다.

## 변경 사항

`moit.kr` A 레코드 하나를 추가했습니다.

| 이름 | 타입 | 값 |
|---|---|---|
| `moit.kr` | A | `216.198.79.1` (Vercel) |

Route53 alias는 대상이 AWS 리소스일 때만 쓸 수 있어, Vercel로 보내려면 A 레코드로 IP를 직접 지정해야 합니다. apex에 CNAME은 DNS 규격상 불가능하지만 A 레코드는 문제없습니다.

## prod 전용인 이유

`count = var.environment == "prod" ? 1 : 0` 조건을 걸었습니다.

sandbox는 `route53_zone_name`과 `alb_domain_name`이 **둘 다 `dev.moit.kr`** 이라(`component/prod/main.tf:3-4`), 조건 없이 만들면 기존 `alb_alias` 레코드와 같은 이름·같은 타입의 A 레코드가 중복되어 충돌합니다.

## 영향 범위

- `api.moit.kr`(백엔드 ALB) — 영향 없음, 별개 레코드
- ACM 인증서 — 영향 없음, `api.moit.kr` 전용이며 변경하지 않음. Vercel은 자체적으로 인증서를 발급합니다
- sandbox — 레코드가 생성되지 않아 변화 없음

## 확인 사항

- [ ] Vercel 대시보드에서 `moit.kr` 추가 시 안내되는 A 레코드 값이 `216.198.79.1`과 일치하는지 확인
- [ ] Vercel 프로젝트에 `moit.kr` 도메인 등록

## 테스트

`terraform validate` 통과. 실제 자격증명으로 `plan`은 돌리지 않았습니다.

`sandbox-api.moit.kr` / `dev.moit.kr` 환경 분리는 계정 간 hosted zone 소유권 정리가 필요해 이번 PR 범위에서 제외했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)